### PR TITLE
Gain split method choice

### DIFF
--- a/backend/deuxpots/individualize.py
+++ b/backend/deuxpots/individualize.py
@@ -6,8 +6,8 @@ from deuxpots.tax_calculator import build_income_sheet, compute_tax, handle_chil
 @dataclass
 class IndividualResult:
     tax_if_single: int = None
-    proportion: int = None
     total_tax: int = None
+    tax_gain: int = None
     already_paid: int = None
     remains_to_pay: int = None
 
@@ -16,36 +16,45 @@ class IndividualResult:
 class IndividualizedResults:
     total_tax_single: int = None
     total_tax_together: int = None
-    tax_gain: int = None
-    partners: Tuple[IndividualResult, IndividualResult] = None
+    total_tax_gain: int = None
+    partners_proportional_split: Tuple[IndividualResult, IndividualResult] = None
+    partners_equal_split: Tuple[IndividualResult, IndividualResult] = None
 
-
-def _individualize(simu_partner_0, simu_partner_1, simu_together):
-    res = IndividualizedResults(
-        total_tax_single=simu_partner_0.total_tax + simu_partner_1.total_tax,
-        total_tax_together=simu_together.total_tax,
-        partners=(
-            IndividualResult(
-                tax_if_single=simu_partner_0.total_tax,
-                already_paid=simu_partner_0.already_paid
-            ),
-            IndividualResult(
-                tax_if_single=simu_partner_1.total_tax,
-                already_paid=simu_partner_1.already_paid
+    @staticmethod
+    def from_simulations(simu_partner_0, simu_partner_1, simu_together):
+        def _default_partner_results():
+            return (
+                IndividualResult(
+                    tax_if_single=simu_partner_0.total_tax,
+                    already_paid=simu_partner_0.already_paid
+                ),
+                IndividualResult(
+                    tax_if_single=simu_partner_1.total_tax,
+                    already_paid=simu_partner_1.already_paid
+                )
             )
-        )
-    )
-    for pix in [0, 1]:
-        partner = res.partners[pix]
-        if res.total_tax_single == 0:
-            partner.proportion == None
-            partner.total_tax = 0
-        else:
-            partner.proportion = partner.tax_if_single / res.total_tax_single
-            partner.total_tax = partner.proportion * res.total_tax_together
-        partner.remains_to_pay = partner.total_tax - partner.already_paid
-    res.tax_gain = res.total_tax_single - res.total_tax_together
-    return res
+        return IndividualizedResults(
+            total_tax_single=simu_partner_0.total_tax + simu_partner_1.total_tax,
+            total_tax_together=simu_together.total_tax,
+            partners_proportional_split=_default_partner_results(),
+            partners_equal_split=_default_partner_results(),
+        )._individualize()
+
+    def _individualize(self):
+        self.total_tax_gain = self.total_tax_single - self.total_tax_together
+        for pix in [0, 1]:
+            partner_proportional = self.partners_proportional_split[pix]
+            partner_even = self.partners_equal_split[pix]
+            if self.total_tax_single == 0:
+                partner_proportion = 0
+            else:
+                partner_proportion = partner_proportional.tax_if_single / self.total_tax_single
+            partner_proportional.tax_gain = self.total_tax_gain * partner_proportion
+            partner_even.tax_gain = self.total_tax_gain / 2
+            for partner in (partner_proportional, partner_even):
+                partner.total_tax = partner.tax_if_single - partner.tax_gain
+                partner.remains_to_pay = partner.total_tax - partner.already_paid
+        return self
 
 
 def simulate_and_individualize(valboxes):
@@ -54,6 +63,8 @@ def simulate_and_individualize(valboxes):
         income_sheet = build_income_sheet(valboxes, individualize=pix)
         income_sheet = handle_children_split(income_sheet)
         simu_results[pix] = compute_tax(income_sheet)
-    return _individualize(simu_partner_0=simu_results[0],
-                          simu_partner_1=simu_results[1],
-                          simu_together=simu_results[None])
+    return IndividualizedResults.from_simulations(
+        simu_partner_0=simu_results[0],
+        simu_partner_1=simu_results[1],
+        simu_together=simu_results[None]
+    )

--- a/backend/test/test_app.py
+++ b/backend/test/test_app.py
@@ -58,7 +58,8 @@ def test_individualize():
                                json=dict(boxes=user_boxes))
         assert res.status_code == 200
         assert res.json['individualized']
-        assert 'partners' in res.json['individualized']
+        assert 'partners_proportional_split' in res.json['individualized']
+        assert 'partners_equal_split' in res.json['individualized']
 
 
 def test_full_scenario(tax_sheet_pdf_path):
@@ -79,4 +80,5 @@ def test_full_scenario(tax_sheet_pdf_path):
                                json=dict(boxes=flatboxes))
         assert res.status_code == 200
         assert res.json['individualized']
-        assert 'partners' in res.json['individualized']
+        assert 'partners_proportional_split' in res.json['individualized']
+        assert 'partners_equal_split' in res.json['individualized']

--- a/frontend/src/components/ResultsPanel.js
+++ b/frontend/src/components/ResultsPanel.js
@@ -1,55 +1,98 @@
-const ResultRow = ({ label, fieldName, partnerIndex, style, results }) => (
+import { useState } from "react";
+import { FaInfoCircle } from "react-icons/fa";
+
+const ResultRow = ({ label, fieldName, partnerIndex, style, partners }) => (
     <div className="py-1 row" style={style}>
         <div className="col-lg-8">
             {label}&nbsp;:
         </div>
         <div className="col-lg-4 text-end">
-            <strong>{ Math.round(results.partners[partnerIndex][fieldName]).toLocaleString('fr-FR') }&nbsp;€</strong>
+            <strong>{ Math.round(partners[partnerIndex][fieldName]).toLocaleString('fr-FR') }&nbsp;€</strong>
         </div>
     </div>
 );
 
-const FinalResult = ({ results, partnerIndex }) => {
-    if (results.partners[partnerIndex].remains_to_get_back && results.partners[1 - partnerIndex].remains_to_pay) {
+const FinalResult = ({ partners, partnerIndex }) => {
+    if (partners[partnerIndex].remains_to_get_back && partners[1 - partnerIndex].remains_to_pay) {
         return <ResultRow label="Reste à récupérer auprès de votre co-déclarant·e" fieldName="remains_to_get_back" partnerIndex={partnerIndex}
-                results={results} style={{fontSize: '1.5em'}} />
+                partners={partners} style={{fontSize: '1.5em'}} />
     }
-    if ((results.partners[partnerIndex].remains_to_pay && results.partners[1 - partnerIndex].remains_to_get_back)) {
+    if ((partners[partnerIndex].remains_to_pay && partners[1 - partnerIndex].remains_to_get_back)) {
         return <ResultRow label="Reste à payer aux impôts" fieldName="remains_to_pay" partnerIndex={partnerIndex}
-                results={results} style={{fontSize: '1.5em'}} />
+                partners={partners} style={{fontSize: '1.5em'}} />
     }
-    if ((results.partners[partnerIndex].remains_to_get_back && results.partners[1 - partnerIndex].remains_to_get_back)) {
+    if ((partners[partnerIndex].remains_to_get_back && partners[1 - partnerIndex].remains_to_get_back)) {
         return <ResultRow label="Reste à récupérer" fieldName="remains_to_get_back" partnerIndex={partnerIndex} 
-                results={results} style={{fontSize: '1.5em'}} />
+                partners={partners} style={{fontSize: '1.5em'}} />
     }
     return <ResultRow label="Reste à payer" fieldName="remains_to_pay" partnerIndex={partnerIndex}
-            results={results} style={{fontSize: '1.5em'}} />
+            partners={partners} style={{fontSize: '1.5em'}} />
 }
 
-const ResultCard = ({ results, partnerIndex }) =>
-    results && (
+const ResultCard = ({ partners, partnerIndex }) =>
+    partners && (
         <div className="card">
             <div className="card-header">
                 Déclarant·e {partnerIndex + 1}
             </div>
             <div className="card-body">
-                <ResultRow label="Impôt si déclaration séparée" fieldName="tax_if_single" partnerIndex={partnerIndex} results={results} style={{color: 'gray'}} />
-                <ResultRow label="Impôt commun individualisé" fieldName="total_tax" partnerIndex={partnerIndex} results={results} style={{}} />
-                <ResultRow label="Déjà payé" fieldName="already_paid" partnerIndex={partnerIndex} results={results} style={{color: 'gray'}} />
-                <FinalResult results={results} partnerIndex={partnerIndex} />
+                <ResultRow label="Impôt si déclaration séparée" fieldName="tax_if_single" partnerIndex={partnerIndex} partners={partners} style={{color: 'gray'}} />
+                <ResultRow label="Impôt commun individualisé" fieldName="total_tax" partnerIndex={partnerIndex} partners={partners} style={{}} />
+                <ResultRow label="Déjà payé" fieldName="already_paid" partnerIndex={partnerIndex} partners={partners} style={{color: 'gray'}} />
+                <FinalResult partners={partners} partnerIndex={partnerIndex} />
             </div>
         </div>
     )
 
-export const ResultsPanel = ({ results }) => (
-    <div>
+export const ResultsPanel = ({ results }) => {
+    const [gainSplitMethod, setGainSplitMethod] = useState("equal");
+    const handleSplitMethodChange = (evt) => setGainSplitMethod(evt.target.value)
+    if (!results) {
+        return
+    }
+
+    const partners = (gainSplitMethod == "equal") ? results.partners_equal_split : results.partners_proportional_split
+    return <div>
+        {(results.total_tax_gain > 10) &&
+        <div className="row">
+            <div className="col-12">
+                <div className="alert alert-primary" role="alert">
+                    <FaInfoCircle /> <strong>La déclaration commune induit une baisse de l'impôt total de {results.total_tax_gain.toLocaleString('fr-FR')} €.
+                    Comment souhaitez-vous répartir cette somme&nbsp;?</strong>
+                    <form>
+                        <div className="row">
+                            <div className="col-lg-6">
+                                <div className="form-check">
+                                    <input className="form-check-input" type="radio" name="flexRadioDefault" id="radioSplitEqual"
+                                    value="equal" onChange={handleSplitMethodChange} checked={gainSplitMethod == "equal"} />
+                                    <label className="form-check-label" for="radioSplitEqual">
+                                        À parts égales ({Math.round(results.partners_equal_split[0].tax_gain).toLocaleString('fr-FR')}&nbsp;€ chacun·e),
+                                    </label>
+                                </div>
+                            </div>
+                                <div className="col-lg-6">
+                                    <div className="form-check">
+                                    <input className="form-check-input" type="radio" id="radioSplitProportional" name="flexRadioDefault"
+                                    value="proportional" onChange={handleSplitMethodChange} checked={gainSplitMethod == "proportional"} />
+                                    <label className="form-check-label" for="radioSplitProportional">
+                                        En proportion de l'impôt dû
+                                        ({Math.round(results.partners_proportional_split[0].tax_gain).toLocaleString('fr-FR')}&nbsp;€
+                                        et {Math.round(results.partners_proportional_split[1].tax_gain).toLocaleString('fr-FR')}&nbsp;€).
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>}
         <div className="row justify-content-center">
             <div className="p-3 col-md-6 col-xl-5">
-                <ResultCard results={results} partnerIndex={0} />
+                <ResultCard partners={partners} partnerIndex={0} />
             </div>
             <div className="p-3 col-md-6 col-xl-5">
-                <ResultCard results={results} partnerIndex={1} />
+                <ResultCard partners={partners} partnerIndex={1} />
             </div>
         </div>
     </div>
-)
+}

--- a/frontend/src/components/TaxBoxesPanel.js
+++ b/frontend/src/components/TaxBoxesPanel.js
@@ -150,12 +150,16 @@ export const TaxBoxesPanel = ({ boxes, setBoxes, setIndividualizedResults, isDem
         ).then(
             data => {
                 const results = data.individualized;
-                [0, 1].forEach(partnerIndex => {
-                    if (results.partners[partnerIndex].remains_to_pay < 0) {
-                        results.partners[partnerIndex].remains_to_get_back = - results.partners[partnerIndex].remains_to_pay
-                        results.partners[partnerIndex].remains_to_pay = null
-                    }
-                })
+                [0, 1].forEach(
+                    partnerIndex => ["partners_equal_split", "partners_proportional_split"].forEach(
+                        partners => {
+                            if (results[partners][partnerIndex].remains_to_pay < 0) {
+                                results[partners][partnerIndex].remains_to_get_back = - results[partners][partnerIndex].remains_to_pay
+                                results[partners][partnerIndex].remains_to_pay = null
+                            }
+                        }
+                    )
+                )
                 setIndividualizedResults(results)
                 setStep({current: 3, max: 3})
             }


### PR DESCRIPTION
Can now choose how to split the amount gained from the common tax return: either proportional (which was the default method before) or equally split.