### PR TITLE
Auto-resolve SIMULATOR_URL based on current year

### DIFF
--- a/backend/deuxpots/__init__.py
+++ b/backend/deuxpots/__init__.py
@@ -1,3 +1,4 @@
+from datetime import date
 from os import environ
 from pathlib import Path
 
@@ -8,4 +9,19 @@ DEV_MODE = not environ.get('FLY_APP_NAME')
 CATEGORY_COORDS_PATH = ROOT_PATH / "resources/category_coords.json"
 CERFA_VARIABLES_PATH = ROOT_PATH / "resources/cerfa_variables.json"
 
-SIMULATOR_URL = "https://simulateur-ir-ifi.impots.gouv.fr/cgi-bin/calc-2025.cgi"
+_SIMULATOR_URL_TEMPLATE = "https://simulateur-ir-ifi.impots.gouv.fr/cgi-bin/calc-{year}.cgi"
+_confirmed_urls = {}  # year -> url, only populated on successful HEAD
+
+
+def get_simulator_url():
+    import requests
+    current_year = date.today().year
+    if current_year not in _confirmed_urls:
+        url = _SIMULATOR_URL_TEMPLATE.format(year=current_year)
+        try:
+            resp = requests.head(url, timeout=5)
+            if resp.status_code < 400:
+                _confirmed_urls[current_year] = url
+        except requests.RequestException:
+            pass
+    return _confirmed_urls.get(current_year, _SIMULATOR_URL_TEMPLATE.format(year=current_year - 1))

--- a/backend/deuxpots/tax_calculator.py
+++ b/backend/deuxpots/tax_calculator.py
@@ -5,7 +5,7 @@ import logging
 from bs4 import BeautifulSoup
 import requests as rq
 
-from deuxpots import SIMULATOR_URL
+from deuxpots import get_simulator_url
 from deuxpots.warning_error_utils import UserFacingError
 
 
@@ -54,7 +54,7 @@ def _rename_variables(income_sheet):
 
 def _simulator_api(income_sheet):
     income_sheet = _rename_variables(income_sheet)
-    resp = rq.post(SIMULATOR_URL, data=income_sheet)
+    resp = rq.post(get_simulator_url(), data=income_sheet)
     try:
         resp.raise_for_status()
     except rq.HTTPError:

--- a/backend/test/test_tax_calculator.py
+++ b/backend/test/test_tax_calculator.py
@@ -2,7 +2,7 @@ import pytest
 import requests as rq
 from deuxpots.box import Box, BoxKind, ReferenceBox
 from deuxpots.tax_calculator import (
-    SIMULATOR_URL, SimulatorError, SimulatorResult,
+    SimulatorError, SimulatorResult,
     _format_simulator_results, _simulator_api, build_income_sheet, compute_tax, handle_children_split
 )
 from deuxpots.valued_box import ValuedBox


### PR DESCRIPTION
Dynamically resolve the simulator URL using the current year instead of hardcoding it. Falls back to the previous year if the current year's URL is not yet available.